### PR TITLE
Alustava mekanismi bootstrappaaville importeille

### DIFF
--- a/vihreat/.gitignore
+++ b/vihreat/.gitignore
@@ -1,0 +1,1 @@
+debug_export.json

--- a/vihreat/data/ontology.json
+++ b/vihreat/data/ontology.json
@@ -1,0 +1,14 @@
+[
+    {
+        "@id": "http://localhost:9883/o",
+        "https://atomicdata.dev/properties/isA": [
+            "https://atomicdata.dev/class/ontology"
+        ],
+        "https://atomicdata.dev/properties/parent": "http://localhost:9883",
+        "https://atomicdata.dev/properties/shortname": "ontology",
+        "https://atomicdata.dev/properties/description": "Vihreiden ohjelma-alustan ontologia",
+        "https://atomicdata.dev/properties/classes": [],
+        "https://atomicdata.dev/properties/properties": [],
+        "https://atomicdata.dev/properties/instances": []
+    }
+]

--- a/vihreat/init.sh
+++ b/vihreat/init.sh
@@ -1,0 +1,18 @@
+set -e
+
+# cd into repository root
+cd $(dirname $(realpath $0))
+cd ..
+
+# Make sure the server is up to date
+cargo build
+
+# Wipe out existing database (the user will need to confirm with "y").
+# Fails if database does not exist in the first place, so we suppress failures here.
+./target/debug/atomic-server reset || true
+
+# Import bootstrap data
+./target/debug/atomic-server import --file vihreat/data/ontology.json --force
+
+# Export
+./target/debug/atomic-server export -p vihreat/debug_export.json


### PR DESCRIPTION
Ajatus on, että kehittäjä voi ajaa `./vihreat/init.sh` ja saa tällä tavalla ajettua testidatat tietokantaan.

Nyt testidatoissa on pelkästään tuo yksi tyhjä ontologia, mutta ajatuksena on, että tuohon voidaan lisätä paitsi ontologian varsinainen sisältö (luokkia, propertyja), myös ohjelmasisältöjä, joita vastaan voi testata.

Ajattelin kirjoittaa myöhemmin tälle kaveriksi skriptin, jolla voi ajaa markdown-muotoisia ohjelmia (näitähän meillä olikin siinä toisessa repossa) JSON-LD -formaattiin, josta ne voidaan importata atomic dataan.