### PR TITLE
Paranna otsikon esitystä tietorakenteessa

### DIFF
--- a/browser/vihreat-lib/src/components/ProgramView.tsx
+++ b/browser/vihreat-lib/src/components/ProgramView.tsx
@@ -11,15 +11,18 @@ interface ProgramViewProps {
 
 export function ProgramView({ resource }: ProgramViewProps): JSX.Element {
   const [title] = useString(resource, ontology.properties.title);
-  const approvedOn = useDate(resource, ontology.properties.approvedon);
+  const [subtitle] = useString(resource, ontology.properties.subtitle);
   const [elements] = useArray(resource, ontology.properties.elements);
+  const approvedOn = useDate(resource, ontology.properties.approvedon);
 
   if (title !== undefined && elements !== undefined) {
     return (
       <div className='vo-container'>
-        <Title title={title} />
-        <FrontMatter approvedOn={approvedOn} />
-        <Body elements={elements} />
+        <Title title={title} subtitle={subtitle} />
+        <div className='vo-program-content'>
+          <FrontMatter approvedOn={approvedOn} />
+          <Body elements={elements} />
+        </div>
       </div>
     );
   } else {

--- a/browser/vihreat-lib/src/components/program/Title.tsx
+++ b/browser/vihreat-lib/src/components/program/Title.tsx
@@ -1,9 +1,22 @@
 interface TitleProps {
   title: string;
+  subtitle?: string;
 }
 
-export function Title({ title }: TitleProps): JSX.Element {
-  return (
-    <h1 className="vo-program-title">{title}</h1>
-  );
+export function Title({ title, subtitle }: TitleProps): JSX.Element {
+  if (subtitle) {
+    return (
+      <div className="vo-program-titlematter">
+        <h1 className="vo-program-title">{title}</h1>
+        <h1 className="vo-program-subtitle">{subtitle}</h1>
+      </div>
+    );
+  } else {
+    return (
+      <div className="vo-program-titlematter">
+        <h1 className="vo-program-title">{title}</h1>
+      </div>
+    );
+
+  }
 }

--- a/browser/vihreat-lib/src/ontologies/ontology.ts
+++ b/browser/vihreat-lib/src/ontologies/ontology.ts
@@ -14,6 +14,7 @@ export const ontology = {
   },
   properties: {
     title: 'http://localhost:9883/o/title',
+    subtitle: 'http://localhost:9883/o/subtitle',
     elements: 'http://localhost:9883/o/elements',
     approvedon: 'http://localhost:9883/o/approvedOn',
     text: 'http://localhost:9883/o/text',
@@ -33,7 +34,9 @@ declare module '@tomic/lib' {
         | BaseProps
         | typeof ontology.properties.title
         | typeof ontology.properties.elements;
-      recommends: typeof ontology.properties.approvedon;
+      recommends:
+        | typeof ontology.properties.subtitle
+        | typeof ontology.properties.approvedon;
     };
     [ontology.classes.title]: {
       requires:
@@ -54,6 +57,7 @@ declare module '@tomic/lib' {
 
   interface PropTypeMapping {
     [ontology.properties.title]: string;
+    [ontology.properties.subtitle]: string;
     [ontology.properties.elements]: string[];
     [ontology.properties.approvedon]: string;
     [ontology.properties.text]: string;
@@ -62,6 +66,7 @@ declare module '@tomic/lib' {
 
   interface PropSubjectToNameMapping {
     [ontology.properties.title]: 'title';
+    [ontology.properties.subtitle]: 'subtitle';
     [ontology.properties.elements]: 'elements';
     [ontology.properties.approvedon]: 'approvedon';
     [ontology.properties.text]: 'text';

--- a/browser/vihreat-ohjelmat/src/App.css
+++ b/browser/vihreat-ohjelmat/src/App.css
@@ -4,13 +4,27 @@
   padding: 2rem;
 }
 
-.vo-program-title {
+h1.vo-program-title {
+  color: #006845;
+  text-align: center;
+  margin-bottom: 0;
+}
+
+h1.vo-program-subtitle {
+  text-align: center;
+  font-size: 1.5em;
+}
+
+.vo-program-content {
+  width: 75ch;
+  margin: 0 auto;
+}
+
+.vo-program-frontmatter {
   text-align: center;
 }
 
 .vo-program-body {
-  max-width: 75ch;
-  margin: 0 auto;
   text-align: left;
 }
 

--- a/vihreat-data/generate.py
+++ b/vihreat-data/generate.py
@@ -7,7 +7,8 @@ generate_ld.io.write(
     generate_ld.program.build(
         "md/tietopoliittinen-ohjelma.md",
         name="p0",
-        title="Tietopoliittinen ohjelma",
+        title="Ihmislähtöinen ja kestävä digitalisaatio",
+        subtitle="Tietopoliittinen ohjelma",
         approved_on="2021-05-16",
     ),
     "tietopoliittinen-ohjelma",

--- a/vihreat-data/generate_ld/ontology.py
+++ b/vihreat-data/generate_ld/ontology.py
@@ -9,6 +9,7 @@ def build() -> list[dict]:
         _build_Paragraph(),
         _build_ActionItem(),
         _build_title(),
+        _build_subtitle(),
         _build_elements(),
         _build_approvedOn(),
         _build_text(),
@@ -31,6 +32,7 @@ def _build_ontology() -> dict:
         ],
         url.atomic("properties/properties"): [
             url.local("o/title"),
+            url.local("o/subtitle"),
             url.local("o/elements"),
             url.local("o/approvedOn"),
             url.local("o/text"),
@@ -51,7 +53,10 @@ def _build_Program() -> dict:
             url.local("o/title"),
             url.local("o/elements"),
         ],
-        url.atomic("properties/recommends"): [url.local("o/approvedOn")],
+        url.atomic("properties/recommends"): [
+            url.local("o/subtitle"),
+            url.local("o/approvedOn"),
+        ],
     }
 
 
@@ -108,6 +113,17 @@ def _build_title() -> dict:
         url.atomic("properties/parent"): url.local("o"),
         url.atomic("properties/shortname"): "title",
         url.atomic("properties/description"): "Ohjelman otsikko.",
+        url.atomic("properties/datatype"): url.atomic("datatypes/string"),
+        url.atomic("properties/isA"): [url.atomic("classes/Property")],
+    }
+
+
+def _build_subtitle() -> dict:
+    return {
+        "@id": url.local("o/subtitle"),
+        url.atomic("properties/parent"): url.local("o"),
+        url.atomic("properties/shortname"): "subtitle",
+        url.atomic("properties/description"): "Ohjelman alaotsikko (esim. \"Tietopoliittinen ohjelma\").",
         url.atomic("properties/datatype"): url.atomic("datatypes/string"),
         url.atomic("properties/isA"): [url.atomic("classes/Property")],
     }

--- a/vihreat-data/generate_ld/program.py
+++ b/vihreat-data/generate_ld/program.py
@@ -7,15 +7,25 @@ def build(markdown_path: str, **kwargs) -> list[dict]:
     return elements + [main]
 
 
-def _build_main(elements: list[dict], name: str, title: str, approved_on: str) -> dict:
-    return {
+def _build_main(
+    elements: list[dict],
+    name: str,
+    title: str,
+    subtitle: str | None,
+    approved_on: str | None,
+) -> dict:
+    j = {
         "@id": url.local(f"ohjelmat/{name}"),
         url.atomic("properties/parent"): url.local(),
         url.atomic("properties/isA"): [url.local("o/Program")],
         url.local("o/title"): title,
         url.local("o/elements"): [e["@id"] for e in elements],
-        url.local("o/approvedOn"): approved_on,
     }
+    if subtitle:
+        j[url.local("o/subtitle")] = subtitle
+    if approved_on:
+        j[url.local("o/approvedOn")] = approved_on
+    return j
 
 
 def _build_elements(markdown_path: str, parent_name: str) -> list[dict]:

--- a/vihreat-data/md/tietopoliittinen-ohjelma.md
+++ b/vihreat-data/md/tietopoliittinen-ohjelma.md
@@ -1,5 +1,3 @@
-# Ihmislähtöinen ja kestävä digitalisaatio
-
 ## Johdanto
 
 Digitalisaatio vaikuttaa meihin joka päivä. Se muokkaa yhteiskuntaa nopeasti ja laajasti yhtä aikaa ympäristökriisin, kaupungistumisen, globalisaation sekä väestön vanhenemisen ja moninaistumisen rinnalla. Vahvalla uudella politiikalla varmistetaan, että digitalisaatioon liittyvien muutosten vaikutukset ovat ihmisten ja ympäristön kannalta myönteisiä.


### PR DESCRIPTION
Muuttaa ohjelman tietorakennetta niin, että sillä on:

* Pakollinen `title`, esim. `Ihmislähtöinen ja kestävä digitalisaatio`
* Valinnainen `subtitle`, esim. `Tietopoliittinen ohjelma`

Aikaisemmin oli vain `title` joka oli `Tietopoliittinen ohjelma`, ja ohjelman varsinainen otsikko (`Ihmislähtöinen ja kestävä digitalisaatio`) oli yksinkertaisesti osa ohjelman sisältöä.

![Screenshot from 2024-07-14 10-36-10](https://github.com/user-attachments/assets/6e735862-9ccb-409e-9f4e-907f67b44ac0)
